### PR TITLE
Do not check unbound variables

### DIFF
--- a/templates/runner.sh.j2
+++ b/templates/runner.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -vxeuo pipefail
+set -vxeo pipefail
 
 {% for key, value in params.items() -%}
 export {{key}}="{{value}}"


### PR DESCRIPTION
Reason: conda activation scripts do not work in some cases

## Example
From https://github.com/nsls2-conda-envs/nsls2-collection-tiled/actions/runs/6512890203/job/17691418677?pr=24:

```bash
/opt/conda/envs/2023-3.2-py310-tiled/etc/conda/activate.d/gdal-activate.sh: line 6: GDAL_DATA: unbound variable
```