### PR TITLE
Add eman2 for cryoem

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
+          mamba-version: "1.5.1
           channels: conda-forge
 
       - name: Install documentation-building requirements

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           auto-update-conda: true
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
-          mamba-version: "1.5.1
+          mamba-version: "1.5.1"
           channels: conda-forge
 
       - name: Install documentation-building requirements

--- a/configs/eman2.yml
+++ b/configs/eman2.yml
@@ -1,0 +1,8 @@
+docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
+env_name: "eman2-2.99.54"
+python_version: "3.10"
+pkg_name: ""
+pkg_version: ""
+extra_packages: "eman-dev"
+channels: "-c cryoem -c conda-forge"
+extra_cmd_before_install: "yum install mesa-libGL -y"


### PR DESCRIPTION
CryoEM requires EMAN2 to be made installable via Ansible. This software is available from the "cryoem" channel as "eman-dev".

Currently testing on gpu3, will make a template on Explorer once we are happy that it works as expected.